### PR TITLE
Silently swallow non-packet packets

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/Packet.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/Packet.java
@@ -104,7 +104,7 @@ public class Packet {
             throw new IllegalStateException("Could not find packet class! Therefore this class is broken.");
         }
 
-        if(!Reflector.inheritsFrom(nmsPacket.getClass(), NMS_PACKET_CLASS)){
+        if(!isNmsPacket(nmsPacket)){
             throw new IllegalArgumentException("You must pass a 'Packet' object!");
         }
 
@@ -113,6 +113,16 @@ public class Packet {
         } catch(Exception e){
             throw new RuntimeException("Failed to create packet!", e);
         }
+    }
+
+    /**
+     * Returns true if the given object is a NMS packet.
+     *
+     * @param nmsPacket the object to check
+     * @return true if the given object is a NMS packet
+     */
+    public static boolean isNmsPacket(Object nmsPacket){
+        return Reflector.inheritsFrom(nmsPacket.getClass(), NMS_PACKET_CLASS);
     }
 
     /**

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/PacketInjector.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/PacketInjector.java
@@ -1,12 +1,12 @@
 package kernitus.plugin.OldCombatMechanics.utilities.packet;
 
-import kernitus.plugin.OldCombatMechanics.utilities.Messenger;
-import kernitus.plugin.OldCombatMechanics.utilities.reflection.Reflector;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import kernitus.plugin.OldCombatMechanics.utilities.Messenger;
+import kernitus.plugin.OldCombatMechanics.utilities.reflection.Reflector;
 import org.bukkit.entity.Player;
 
 import java.lang.ref.WeakReference;
@@ -150,6 +150,11 @@ class PacketInjector extends ChannelDuplexHandler {
             return;
         }
 
+        if(!Packet.isNmsPacket(packet)){
+            debug("Received a packet THAT IS NO PACKET: " + packet.getClass() + " " + packet);
+            return;
+        }
+
         PacketEvent event = new PacketEvent(
                 packet,
                 PacketEvent.ConnectionDirection.TO_CLIENT,
@@ -183,6 +188,11 @@ class PacketInjector extends ChannelDuplexHandler {
 
             // bubble up
             super.channelRead(channelHandlerContext, packet);
+            return;
+        }
+
+        if(!Packet.isNmsPacket(packet)){
+            debug("Received a packet THAT IS NO PACKET: " + packet.getClass() + " " + packet);
             return;
         }
 


### PR DESCRIPTION
## Description
If the packet listener receives a non-NMS packet, it threw a fit and crashed, disconnecting the player.

## Mitigation
Check for that and silently ignore packets, that do not extend the NMS Packet class.

## Notes
The problem is still logged in debug mode, to ease debugging.

## Closes
#355