### PR TITLE
Fixes Memoryleak 

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleSwordBlocking.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleSwordBlocking.java
@@ -88,7 +88,7 @@ public class ModuleSwordBlocking extends Module {
             inv.setItemInOffHand(SHIELD);
         }
 
-        scheduleRestore(p);
+        postponeRestoring(p);
     }
 
     @EventHandler


### PR DESCRIPTION
Prevent RunnableSeries to stay in memory when putting a new instance into correspondingTasks (GC will never destroy it)