### PR TITLE
Prevent duplicate packet listener registrations

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/PacketInjector.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/PacketInjector.java
@@ -113,6 +113,8 @@ class PacketInjector extends ChannelDuplexHandler {
         if(isClosed){
             throw new IllegalStateException("Channel already closed. Adding of listener invalid");
         }
+        // prevent duplicate registrations
+        packetListeners.remove(packetListener);
         packetListeners.add(packetListener);
     }
 


### PR DESCRIPTION
Previously the attack sound module would attach two listeners after a reload. This doesn't really hurt as they will come to the same
conclusion, but it is just wasted computation time.

There are likely more elegant solutions than the unconditional remove, but packet listeners are registered only at startup / ocm reload / reload.

This also only works when the modules cache their packet listeners and reuse them (as otherwise they will not be the same object and not equal) but the current modules are nice enough to do that.