### PR TITLE
Cache SweepPacketDetector

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleSwordSweep.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleSwordSweep.java
@@ -143,6 +143,11 @@ public class ModuleSwordSweep extends Module {
     private class ParticleListener extends PacketAdapter {
 
         private boolean disabledDueToError;
+        private final SweepPacketDetector packetDetector;
+
+        public ParticleListener(){
+            this.packetDetector = SweepPacketDetector.getInstance();
+        }
 
         @Override
         public void onPacketSend(PacketEvent packetEvent){
@@ -151,7 +156,7 @@ public class ModuleSwordSweep extends Module {
             }
 
             try{
-                if(SweepPacketDetector.getInstance().isSweepPacket(packetEvent.getPacket())){
+                if(packetDetector.isSweepPacket(packetEvent.getPacket())){
                     packetEvent.setCancelled(true);
                 }
             } catch(Exception e){


### PR DESCRIPTION
Previously the SweepPacketDetector instance was recreated every time (god knows why, I blame some refactoring).

## Closes
#429 I hope

If it is still too slow, we should be able to switch to static final MethodHandles for the checks, which the JVM can optimize quite a bit more.