### PR TITLE
Rework player collision packet manipulation

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/teams/TeamAction.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/teams/TeamAction.java
@@ -10,7 +10,7 @@ public enum TeamAction {
     ADD_PLAYER(3),
     REMOVE_PLAYER(4);
 
-    private int minecraftId;
+    private final int minecraftId;
 
     TeamAction(int minecraftId){
         this.minecraftId = minecraftId;


### PR DESCRIPTION
There were quite a few bug reports about players being kicked as a team was created again.
This was caused by the updateToPacket method adjusting the ID of the new packet to the ID of an older one, leading to duplicated packets.
Packet queueing and sending can have a large delay and lead to packets appearing out of order or after they were already replaced.

This patch changes the mechanism:
- Packets are not changed but new ones are created
- The *last* packet is kept
- OCM now does not generate random names but instead counts upwards
- OCM now tries to correctly disband its own teams
- A few cases in which OCM created more teams than needed were fixed

### References issues
Closes #457 and maybe #424, #406 and #403?