### PR TITLE
Added module for reverting fishing rod velocity back to 1.8

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/OCMMain.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/OCMMain.java
@@ -188,6 +188,8 @@ public class OCMMain extends JavaPlugin {
 
         ModuleLoader.addModule(new ModuleAttackSounds(this));
         ModuleLoader.addModule(new ModuleOldBurnDelay(this));
+
+        ModuleLoader.addModule(new ModuleFishingRodVelocity(this));
     }
 
     private void registerHooks(){

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleFishingRodVelocity.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleFishingRodVelocity.java
@@ -1,62 +1,115 @@
 package kernitus.plugin.OldCombatMechanics.module;
 
 import kernitus.plugin.OldCombatMechanics.OCMMain;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.FishHook;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.entity.ProjectileLaunchEvent;
-import org.bukkit.projectiles.ProjectileSource;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.util.Vector;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Random;
 
 public class ModuleFishingRodVelocity extends Module {
+    public static HashSet<FishHook> fishHooks = new HashSet<>();
+    boolean versionChagesGravity;
     Random rand = new Random();
+    Method getHook;
 
     /**
-     * 1.9 changed the formula used for fishing rod velocity to be a bit slower.
-     * This module uses the exact 1.8 formula in order to revert this change.
-     * Some error in velocity occurs due to other changes in 1.9
+     * This module uses the exact 1.8 formula in order to revert fishing rod gravity
+     * and fishing rod velocity back to 1.8
+     *
+     * Fishing rod gravity in 1.9+ is 0.04 while in 1.8 it is 0.03
+     * Launch velocity in 1.9+ was also changed from the 1.8 formula
      */
 
     public ModuleFishingRodVelocity(OCMMain plugin) {
-        super(plugin, "old-fishing-rod-velocity");
+        super(plugin, "fishing-rod-velocity");
+
+        // 1.14 versions and higher change gravity in testing, while 1.13 versions and lower
+        // have the same fishing hook gravity as 1.8
+        versionChagesGravity = !Bukkit.getVersion().contains("1.13") && !Bukkit.getVersion().contains("1.12") && !Bukkit.getVersion().contains("1.11") && !Bukkit.getVersion().contains("1.10") && !Bukkit.getVersion().contains("1.9");
+
+        try {
+            // Reflection because in 1.12- this method returns the Fish class, which was renamed to FishHook in 1.13+
+            getHook = PlayerFishEvent.class.getMethod("getHook");
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
+
+        OCMMain.getInstance().addEnableListener(() -> Bukkit.getScheduler().runTaskTimer(OCMMain.getInstance(), () -> {
+            Iterator<FishHook> fishingHookIterator = ModuleFishingRodVelocity.fishHooks.iterator();
+
+            while (fishingHookIterator.hasNext()) {
+                FishHook fishHook = fishingHookIterator.next();
+
+                if (!fishHook.isValid()) {
+                    fishingHookIterator.remove();
+                } else if (versionChagesGravity && fishHook.getWorld().getBlockAt(fishHook.getLocation()).getType() != Material.WATER) {
+                    Vector fVelocity = fishHook.getVelocity();
+                    fVelocity.setY(fVelocity.getY() - 0.01);
+                    fishHook.setVelocity(fVelocity);
+                }
+            }
+        }, 1, 1));
     }
 
     @EventHandler
-    public void onFishingRodCast(ProjectileLaunchEvent event) {
-        if (event.getEntity() instanceof FishHook) {
-            Projectile fishHook = event.getEntity();
-            ProjectileSource caster = fishHook.getShooter();
+    public void onFishEvent(PlayerFishEvent event) throws InvocationTargetException, IllegalAccessException {
+        FishHook fishHook = (FishHook) getHook.invoke(event);
 
-            if (caster instanceof Player) {
-                Player casterPlayer = (Player) caster;
-                double playerYaw = casterPlayer.getLocation().getYaw();
-                double playerPitch = casterPlayer.getLocation().getPitch();
+        if(!isEnabled(fishHook.getWorld())) return;
 
-                float oldMaxVelocity = 0.4F;
-                double velocityX = -Math.sin(playerYaw / 180.0F * (float)Math.PI) * Math.cos(playerPitch / 180.0F * (float)Math.PI) * oldMaxVelocity;
-                double velocityZ = Math.cos(playerYaw / 180.0F * (float)Math.PI) * Math.cos(playerPitch / 180.0F * (float)Math.PI) * oldMaxVelocity;
-                double velocityY = -Math.sin(playerPitch / 180.0F * (float)Math.PI) * oldMaxVelocity;
+        if (event.getState() == PlayerFishEvent.State.FISHING) {
+            Player casterPlayer = event.getPlayer();
+            double playerYaw = casterPlayer.getLocation().getYaw();
+            double playerPitch = casterPlayer.getLocation().getPitch();
 
-                double oldVelocityMultiplier = 1.37F; // This is 1.5 in vanilla 1.8, the formula doesn't work exactly as it should
+            float oldMaxVelocity = 0.4F;
+            double velocityX = -Math.sin(playerYaw / 180.0F * (float) Math.PI) * Math.cos(playerPitch / 180.0F * (float) Math.PI) * oldMaxVelocity;
+            double velocityZ = Math.cos(playerYaw / 180.0F * (float) Math.PI) * Math.cos(playerPitch / 180.0F * (float) Math.PI) * oldMaxVelocity;
+            double velocityY = -Math.sin(playerPitch / 180.0F * (float) Math.PI) * oldMaxVelocity;
 
-                float vectorLength = (float) Math.sqrt(velocityX * velocityX + velocityY * velocityY + velocityZ * velocityZ);
-                velocityX = velocityX / (double)vectorLength;
-                velocityY = velocityY / (double)vectorLength;
-                velocityZ = velocityZ / (double)vectorLength;
-                velocityX = velocityX + this.rand.nextGaussian() * 0.007499999832361937D;
-                velocityY = velocityY + this.rand.nextGaussian() * 0.007499999832361937D;
-                velocityZ = velocityZ + this.rand.nextGaussian() * 0.007499999832361937D;
-                velocityX = velocityX * oldVelocityMultiplier;
-                velocityY = velocityY * oldVelocityMultiplier;
-                velocityZ = velocityZ * oldVelocityMultiplier;
+            double oldVelocityMultiplier = 1.5;
 
-                Vector newSpeed = new Vector(velocityX, velocityY, velocityZ);
+            float vectorLength = (float) Math.sqrt(velocityX * velocityX + velocityY * velocityY + velocityZ * velocityZ);
+            velocityX = velocityX / (double) vectorLength;
+            velocityY = velocityY / (double) vectorLength;
+            velocityZ = velocityZ / (double) vectorLength;
+            velocityX = velocityX + this.rand.nextGaussian() * 0.007499999832361937D;
+            velocityY = velocityY + this.rand.nextGaussian() * 0.007499999832361937D;
+            velocityZ = velocityZ + this.rand.nextGaussian() * 0.007499999832361937D;
+            velocityX = velocityX * oldVelocityMultiplier;
+            velocityY = velocityY * oldVelocityMultiplier;
+            velocityZ = velocityZ * oldVelocityMultiplier;
 
-                fishHook.setVelocity(newSpeed);
-            }
+            Vector newSpeed = new Vector(velocityX, velocityY, velocityZ);
+
+            fishHook.setVelocity(newSpeed);
+        }
+    }
+
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onFishingEventMonitor(PlayerFishEvent event) throws InvocationTargetException, IllegalAccessException {
+        FishHook fishHook = (FishHook) getHook.invoke(event);
+
+        if(!isEnabled(fishHook.getWorld())) return;
+
+        if (event.getState() == PlayerFishEvent.State.FISHING) {
+            fishHooks.add(fishHook);
+        }
+
+        if (event.getState()  == PlayerFishEvent.State.IN_GROUND) {
+            fishHooks.remove(fishHook);
         }
     }
 }

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleFishingRodVelocity.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleFishingRodVelocity.java
@@ -19,7 +19,7 @@ import java.util.Random;
 
 public class ModuleFishingRodVelocity extends Module {
     public static HashSet<FishHook> fishHooks = new HashSet<>();
-    boolean versionChagesGravity;
+    public static boolean versionChagesGravity;
     Random rand = new Random();
     Method getHook;
 
@@ -27,8 +27,8 @@ public class ModuleFishingRodVelocity extends Module {
      * This module uses the exact 1.8 formula in order to revert fishing rod gravity
      * and fishing rod velocity back to 1.8
      *
-     * Fishing rod gravity in 1.9+ is 0.04 while in 1.8 it is 0.03
-     * Launch velocity in 1.9+ was also changed from the 1.8 formula
+     * Fishing rod gravity in 1.14+ is 0.04 while in 1.8 it is 0.03
+     * Launch velocity in 1.9+ is also changed from the 1.8 formula
      */
 
     public ModuleFishingRodVelocity(OCMMain plugin) {
@@ -45,21 +45,24 @@ public class ModuleFishingRodVelocity extends Module {
             e.printStackTrace();
         }
 
-        OCMMain.getInstance().addEnableListener(() -> Bukkit.getScheduler().runTaskTimer(OCMMain.getInstance(), () -> {
-            Iterator<FishHook> fishingHookIterator = ModuleFishingRodVelocity.fishHooks.iterator();
+        if (versionChagesGravity) {
+            OCMMain.getInstance().addEnableListener(() -> Bukkit.getScheduler().runTaskTimer(OCMMain.getInstance(), () -> {
 
-            while (fishingHookIterator.hasNext()) {
-                FishHook fishHook = fishingHookIterator.next();
+                Iterator<FishHook> fishingHookIterator = ModuleFishingRodVelocity.fishHooks.iterator();
 
-                if (!fishHook.isValid()) {
-                    fishingHookIterator.remove();
-                } else if (versionChagesGravity && fishHook.getWorld().getBlockAt(fishHook.getLocation()).getType() != Material.WATER) {
-                    Vector fVelocity = fishHook.getVelocity();
-                    fVelocity.setY(fVelocity.getY() - 0.01);
-                    fishHook.setVelocity(fVelocity);
+                while (fishingHookIterator.hasNext()) {
+                    FishHook fishHook = fishingHookIterator.next();
+
+                    if (!fishHook.isValid()) {
+                        fishingHookIterator.remove();
+                    } else if (fishHook.getWorld().getBlockAt(fishHook.getLocation()).getType() != Material.WATER) {
+                        Vector fVelocity = fishHook.getVelocity();
+                        fVelocity.setY(fVelocity.getY() - 0.01);
+                        fishHook.setVelocity(fVelocity);
+                    }
                 }
-            }
-        }, 1, 1));
+            }, 1, 1));
+        }
     }
 
     @EventHandler
@@ -104,7 +107,7 @@ public class ModuleFishingRodVelocity extends Module {
 
         if(!isEnabled(fishHook.getWorld())) return;
 
-        if (event.getState() == PlayerFishEvent.State.FISHING) {
+        if (versionChagesGravity && event.getState() == PlayerFishEvent.State.FISHING) {
             fishHooks.add(fishHook);
         }
 

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleFishingRodVelocity.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleFishingRodVelocity.java
@@ -1,52 +1,46 @@
 package kernitus.plugin.OldCombatMechanics.module;
 
 import kernitus.plugin.OldCombatMechanics.OCMMain;
+import kernitus.plugin.OldCombatMechanics.utilities.reflection.Reflector;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.FishHook;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.util.Vector;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Random;
 
+/**
+ * This module reverts fishing rod gravity and velocity back to 1.8 behaviour
+ * <p>
+ * Fishing rod gravity in 1.14+ is 0.04 while in 1.8 it is 0.03
+ * Launch velocity in 1.9+ is also changed from the 1.8 formula
+ */
 public class ModuleFishingRodVelocity extends Module {
-    public static HashSet<FishHook> fishHooks = new HashSet<>();
-    public static boolean versionChagesGravity;
-    Random rand = new Random();
-    Method getHook;
 
-    /**
-     * This module uses the exact 1.8 formula in order to revert fishing rod gravity
-     * and fishing rod velocity back to 1.8
-     *
-     * Fishing rod gravity in 1.14+ is 0.04 while in 1.8 it is 0.03
-     * Launch velocity in 1.9+ is also changed from the 1.8 formula
-     */
+    private static final HashSet<FishHook> fishHooks = new HashSet<>();
+    private static boolean hasDifferentGravity;
+    private final Random random = new Random();
+    private final Method getHook;
 
     public ModuleFishingRodVelocity(OCMMain plugin) {
         super(plugin, "fishing-rod-velocity");
 
-        // 1.14 versions and higher change gravity in testing, while 1.13 versions and lower
-        // have the same fishing hook gravity as 1.8
-        versionChagesGravity = !Bukkit.getVersion().contains("1.13") && !Bukkit.getVersion().contains("1.12") && !Bukkit.getVersion().contains("1.11") && !Bukkit.getVersion().contains("1.10") && !Bukkit.getVersion().contains("1.9");
+        // Versions 1.14+ have different gravity than previous versions
+        final String bukkitVersion = Bukkit.getBukkitVersion();
+        hasDifferentGravity = Reflector.versionIsNewerOrEqualAs(1, 14, 0);
 
-        try {
-            // Reflection because in 1.12- this method returns the Fish class, which was renamed to FishHook in 1.13+
-            getHook = PlayerFishEvent.class.getMethod("getHook");
-        } catch (NoSuchMethodException e) {
-            e.printStackTrace();
-        }
+        // Reflection because in 1.12- this method returns the Fish class, which was renamed to FishHook in 1.13+
+        getHook = Reflector.getMethod(PlayerFishEvent.class, "getHook");
 
-        if (versionChagesGravity) {
-            OCMMain.getInstance().addEnableListener(() -> Bukkit.getScheduler().runTaskTimer(OCMMain.getInstance(), () -> {
+        if (hasDifferentGravity) {
+            plugin.addEnableListener(() -> Bukkit.getScheduler().runTaskTimer(plugin, () -> {
 
                 Iterator<FishHook> fishingHookIterator = ModuleFishingRodVelocity.fishHooks.iterator();
 
@@ -66,53 +60,48 @@ public class ModuleFishingRodVelocity extends Module {
     }
 
     @EventHandler
-    public void onFishEvent(PlayerFishEvent event) throws InvocationTargetException, IllegalAccessException {
-        FishHook fishHook = (FishHook) getHook.invoke(event);
+    public void onFishEvent(PlayerFishEvent event) {
+        final FishHook fishHook = Reflector.invokeMethod(getHook, event);
 
-        if(!isEnabled(fishHook.getWorld())) return;
+        if (!isEnabled(fishHook.getWorld()) || event.getState() != PlayerFishEvent.State.FISHING) return;
 
-        if (event.getState() == PlayerFishEvent.State.FISHING) {
-            Player casterPlayer = event.getPlayer();
-            double playerYaw = casterPlayer.getLocation().getYaw();
-            double playerPitch = casterPlayer.getLocation().getPitch();
+        Player casterPlayer = event.getPlayer();
+        double playerYaw = casterPlayer.getLocation().getYaw();
+        double playerPitch = casterPlayer.getLocation().getPitch();
 
-            float oldMaxVelocity = 0.4F;
-            double velocityX = -Math.sin(playerYaw / 180.0F * (float) Math.PI) * Math.cos(playerPitch / 180.0F * (float) Math.PI) * oldMaxVelocity;
-            double velocityZ = Math.cos(playerYaw / 180.0F * (float) Math.PI) * Math.cos(playerPitch / 180.0F * (float) Math.PI) * oldMaxVelocity;
-            double velocityY = -Math.sin(playerPitch / 180.0F * (float) Math.PI) * oldMaxVelocity;
+        float oldMaxVelocity = 0.4F;
+        double velocityX = -Math.sin(playerYaw / 180.0F * (float) Math.PI) * Math.cos(playerPitch / 180.0F * (float) Math.PI) * oldMaxVelocity;
+        double velocityZ = Math.cos(playerYaw / 180.0F * (float) Math.PI) * Math.cos(playerPitch / 180.0F * (float) Math.PI) * oldMaxVelocity;
+        double velocityY = -Math.sin(playerPitch / 180.0F * (float) Math.PI) * oldMaxVelocity;
 
-            double oldVelocityMultiplier = 1.5;
+        double oldVelocityMultiplier = 1.5;
 
-            float vectorLength = (float) Math.sqrt(velocityX * velocityX + velocityY * velocityY + velocityZ * velocityZ);
-            velocityX = velocityX / (double) vectorLength;
-            velocityY = velocityY / (double) vectorLength;
-            velocityZ = velocityZ / (double) vectorLength;
-            velocityX = velocityX + this.rand.nextGaussian() * 0.007499999832361937D;
-            velocityY = velocityY + this.rand.nextGaussian() * 0.007499999832361937D;
-            velocityZ = velocityZ + this.rand.nextGaussian() * 0.007499999832361937D;
-            velocityX = velocityX * oldVelocityMultiplier;
-            velocityY = velocityY * oldVelocityMultiplier;
-            velocityZ = velocityZ * oldVelocityMultiplier;
+        float vectorLength = (float) Math.sqrt(velocityX * velocityX + velocityY * velocityY + velocityZ * velocityZ);
+        velocityX = velocityX / (double) vectorLength;
+        velocityY = velocityY / (double) vectorLength;
+        velocityZ = velocityZ / (double) vectorLength;
+        velocityX = velocityX + this.random.nextGaussian() * 0.007499999832361937D;
+        velocityY = velocityY + this.random.nextGaussian() * 0.007499999832361937D;
+        velocityZ = velocityZ + this.random.nextGaussian() * 0.007499999832361937D;
+        velocityX = velocityX * oldVelocityMultiplier;
+        velocityY = velocityY * oldVelocityMultiplier;
+        velocityZ = velocityZ * oldVelocityMultiplier;
 
-            Vector newSpeed = new Vector(velocityX, velocityY, velocityZ);
+        Vector newSpeed = new Vector(velocityX, velocityY, velocityZ);
 
-            fishHook.setVelocity(newSpeed);
-        }
+        fishHook.setVelocity(newSpeed);
     }
 
-
     @EventHandler(priority = EventPriority.MONITOR)
-    public void onFishingEventMonitor(PlayerFishEvent event) throws InvocationTargetException, IllegalAccessException {
-        FishHook fishHook = (FishHook) getHook.invoke(event);
+    public void onFishingEventMonitor(PlayerFishEvent event) {
+        final FishHook fishHook = Reflector.invokeMethod(getHook, event);
 
-        if(!isEnabled(fishHook.getWorld())) return;
+        if (!isEnabled(fishHook.getWorld())) return;
 
-        if (versionChagesGravity && event.getState() == PlayerFishEvent.State.FISHING) {
-            fishHooks.add(fishHook);
-        }
+        final PlayerFishEvent.State state = event.getState();
 
-        if (event.getState()  == PlayerFishEvent.State.IN_GROUND) {
-            fishHooks.remove(fishHook);
-        }
+        if (hasDifferentGravity && state == PlayerFishEvent.State.FISHING) fishHooks.add(fishHook);
+
+        if (state == PlayerFishEvent.State.IN_GROUND) fishHooks.remove(fishHook);
     }
 }

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleFishingRodVelocity.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleFishingRodVelocity.java
@@ -1,0 +1,62 @@
+package kernitus.plugin.OldCombatMechanics.module;
+
+import kernitus.plugin.OldCombatMechanics.OCMMain;
+import org.bukkit.entity.FishHook;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.projectiles.ProjectileSource;
+import org.bukkit.util.Vector;
+
+import java.util.Random;
+
+public class ModuleFishingRodVelocity extends Module {
+    Random rand = new Random();
+
+    /**
+     * 1.9 changed the formula used for fishing rod velocity to be a bit slower.
+     * This module uses the exact 1.8 formula in order to revert this change.
+     * Some error in velocity occurs due to other changes in 1.9
+     */
+
+    public ModuleFishingRodVelocity(OCMMain plugin) {
+        super(plugin, "old-fishing-rod-velocity");
+    }
+
+    @EventHandler
+    public void onFishingRodCast(ProjectileLaunchEvent event) {
+        if (event.getEntity() instanceof FishHook) {
+            Projectile fishHook = event.getEntity();
+            ProjectileSource caster = fishHook.getShooter();
+
+            if (caster instanceof Player) {
+                Player casterPlayer = (Player) caster;
+                double playerYaw = casterPlayer.getLocation().getYaw();
+                double playerPitch = casterPlayer.getLocation().getPitch();
+
+                float oldMaxVelocity = 0.4F;
+                double velocityX = -Math.sin(playerYaw / 180.0F * (float)Math.PI) * Math.cos(playerPitch / 180.0F * (float)Math.PI) * oldMaxVelocity;
+                double velocityZ = Math.cos(playerYaw / 180.0F * (float)Math.PI) * Math.cos(playerPitch / 180.0F * (float)Math.PI) * oldMaxVelocity;
+                double velocityY = -Math.sin(playerPitch / 180.0F * (float)Math.PI) * oldMaxVelocity;
+
+                double oldVelocityMultiplier = 1.37F; // This is 1.5 in vanilla 1.8, the formula doesn't work exactly as it should
+
+                float vectorLength = (float) Math.sqrt(velocityX * velocityX + velocityY * velocityY + velocityZ * velocityZ);
+                velocityX = velocityX / (double)vectorLength;
+                velocityY = velocityY / (double)vectorLength;
+                velocityZ = velocityZ / (double)vectorLength;
+                velocityX = velocityX + this.rand.nextGaussian() * 0.007499999832361937D;
+                velocityY = velocityY + this.rand.nextGaussian() * 0.007499999832361937D;
+                velocityZ = velocityZ + this.rand.nextGaussian() * 0.007499999832361937D;
+                velocityX = velocityX * oldVelocityMultiplier;
+                velocityY = velocityY * oldVelocityMultiplier;
+                velocityZ = velocityZ * oldVelocityMultiplier;
+
+                Vector newSpeed = new Vector(velocityX, velocityY, velocityZ);
+
+                fishHook.setVelocity(newSpeed);
+            }
+        }
+    }
+}

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleFishingRodVelocity.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleFishingRodVelocity.java
@@ -3,9 +3,9 @@ package kernitus.plugin.OldCombatMechanics.module;
 import kernitus.plugin.OldCombatMechanics.OCMMain;
 import kernitus.plugin.OldCombatMechanics.utilities.reflection.Reflector;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.FishHook;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerFishEvent;
@@ -19,7 +19,7 @@ import java.util.Random;
 /**
  * This module reverts fishing rod gravity and velocity back to 1.8 behaviour
  * <p>
- * Fishing rod gravity in 1.14+ is 0.04 while in 1.8 it is 0.03
+ * Fishing rod gravity in 1.14+ is 0.03 while in 1.8 it is 0.04
  * Launch velocity in 1.9+ is also changed from the 1.8 formula
  */
 public class ModuleFishingRodVelocity extends Module {
@@ -33,7 +33,6 @@ public class ModuleFishingRodVelocity extends Module {
         super(plugin, "fishing-rod-velocity");
 
         // Versions 1.14+ have different gravity than previous versions
-        final String bukkitVersion = Bukkit.getBukkitVersion();
         hasDifferentGravity = Reflector.versionIsNewerOrEqualAs(1, 14, 0);
 
         // Reflection because in 1.12- this method returns the Fish class, which was renamed to FishHook in 1.13+
@@ -65,29 +64,31 @@ public class ModuleFishingRodVelocity extends Module {
 
         if (!isEnabled(fishHook.getWorld()) || event.getState() != PlayerFishEvent.State.FISHING) return;
 
-        Player casterPlayer = event.getPlayer();
-        double playerYaw = casterPlayer.getLocation().getYaw();
-        double playerPitch = casterPlayer.getLocation().getPitch();
+        final Location location = event.getPlayer().getLocation();
+        final double playerYaw = location.getYaw();
+        final double playerPitch = location.getPitch();
 
-        float oldMaxVelocity = 0.4F;
+        final float oldMaxVelocity = 0.4F;
         double velocityX = -Math.sin(playerYaw / 180.0F * (float) Math.PI) * Math.cos(playerPitch / 180.0F * (float) Math.PI) * oldMaxVelocity;
         double velocityZ = Math.cos(playerYaw / 180.0F * (float) Math.PI) * Math.cos(playerPitch / 180.0F * (float) Math.PI) * oldMaxVelocity;
         double velocityY = -Math.sin(playerPitch / 180.0F * (float) Math.PI) * oldMaxVelocity;
 
-        double oldVelocityMultiplier = 1.5;
+        final double oldVelocityMultiplier = 1.5;
 
-        float vectorLength = (float) Math.sqrt(velocityX * velocityX + velocityY * velocityY + velocityZ * velocityZ);
-        velocityX = velocityX / (double) vectorLength;
-        velocityY = velocityY / (double) vectorLength;
-        velocityZ = velocityZ / (double) vectorLength;
-        velocityX = velocityX + this.random.nextGaussian() * 0.007499999832361937D;
-        velocityY = velocityY + this.random.nextGaussian() * 0.007499999832361937D;
-        velocityZ = velocityZ + this.random.nextGaussian() * 0.007499999832361937D;
-        velocityX = velocityX * oldVelocityMultiplier;
-        velocityY = velocityY * oldVelocityMultiplier;
-        velocityZ = velocityZ * oldVelocityMultiplier;
+        final double vectorLength = (float) Math.sqrt(velocityX * velocityX + velocityY * velocityY + velocityZ * velocityZ);
+        velocityX /= vectorLength;
+        velocityY /= vectorLength;
+        velocityZ /= vectorLength;
 
-        Vector newSpeed = new Vector(velocityX, velocityY, velocityZ);
+        velocityX += random.nextGaussian() * 0.007499999832361937D;
+        velocityY += random.nextGaussian() * 0.007499999832361937D;
+        velocityZ += random.nextGaussian() * 0.007499999832361937D;
+
+        velocityX *= oldVelocityMultiplier;
+        velocityY *= oldVelocityMultiplier;
+        velocityZ *= oldVelocityMultiplier;
+
+        final Vector newSpeed = new Vector(velocityX, velocityY, velocityZ);
 
         fishHook.setVelocity(newSpeed);
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -246,6 +246,10 @@ old-fishing-knockback:
   # This is the delay in milliseconds in-between rod damage, so the player hit has time to fall back down
   hitCooldown: 1000
 
+old-fishing-rod-velocity:
+  # This is to revert the fishing rod cast to pre-1.9 velocity
+  enabled: true
+
 projectile-knockback:
   # This adds knockback and/or damage to players when they get hit by snowballs, eggs & enderpearls
   # This has been a Bukkit bug for so long people thought it was vanilla when it was recently patched

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -246,9 +246,12 @@ old-fishing-knockback:
   # This is the delay in milliseconds in-between rod damage, so the player hit has time to fall back down
   hitCooldown: 1000
 
-old-fishing-rod-velocity:
-  # This is to revert the fishing rod cast to pre-1.9 velocity
+fishing-rod-velocity:
+  # In 1.9+ fishing rods go 8 blocks instead of 12 blocks
+  # This is due to both gravity and initial launch speed
+  # Set to true to revert back to the old calculations and gravity
   enabled: true
+  worlds: []
 
 projectile-knockback:
   # This adds knockback and/or damage to players when they get hit by snowballs, eggs & enderpearls


### PR DESCRIPTION
The formulas were taken directly from 1.8, although due to other changes, I reduced the final multiplier from 1.5 to 1.37 to better resemble 1.8 rod distance.  Perhaps gravity and air friction are also calculated differently in 1.9+

This fixes issue #149 