### PR TITLE
Cooldown messages

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleGoldenApple.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleGoldenApple.java
@@ -118,9 +118,15 @@ public class ModuleGoldenApple extends Module {
         if(cooldown.isOnCooldown(item, lastEaten.get(p.getUniqueId())))
         {
             long basecd = consumedMaterial == Material.GOLDEN_APPLE ? cooldown.normal : cooldown.enchanted;
+    
+            LastEaten lastEaten = this.lastEaten.get(p.getUniqueId());
+    
             Instant currentcd = consumedMaterial == Material.GOLDEN_APPLE ?
-                    lastEaten.get(p.getUniqueId()).lastNormalEaten :
-                    lastEaten.get(p.getUniqueId()).lastEnchantedEaten;
+                    lastEaten.lastNormalEaten :
+                    lastEaten.lastEnchantedEaten;
+            
+            if(cooldown.sharedCooldown && lastEaten.getNewestEatTime().isPresent())
+                currentcd = lastEaten.getNewestEatTime().get();
 
             long seconds = basecd - (Instant.now().getEpochSecond() - currentcd.getEpochSecond());
             

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleGoldenApple.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleGoldenApple.java
@@ -36,13 +36,13 @@ public class ModuleGoldenApple extends Module {
     private Map<UUID, LastEaten> lastEaten;
     private Cooldown cooldown;
 
-    public ModuleGoldenApple(OCMMain plugin){
+    public ModuleGoldenApple(OCMMain plugin) {
         super(plugin, "old-golden-apples");
     }
 
     @SuppressWarnings("deprecated")
     @Override
-    public void reload(){
+    public void reload() {
         cooldown = new Cooldown(
                 module().getLong("cooldown.normal"),
                 module().getLong("cooldown.enchanted"),
@@ -53,12 +53,12 @@ public class ModuleGoldenApple extends Module {
         enchantedGoldenAppleEffects = getPotionEffects("napple");
         goldenAppleEffects = getPotionEffects("gapple");
 
-        try{
+        try {
             enchantedAppleRecipe = new ShapedRecipe(
                     new NamespacedKey(plugin, "MINECRAFT"),
                     ENCHANTED_GOLDEN_APPLE.newInstance()
             );
-        } catch(NoClassDefFoundError e){
+        } catch (NoClassDefFoundError e) {
             enchantedAppleRecipe = new ShapedRecipe(ENCHANTED_GOLDEN_APPLE.newInstance());
         }
         enchantedAppleRecipe
@@ -69,45 +69,45 @@ public class ModuleGoldenApple extends Module {
         registerCrafting();
     }
 
-    private void registerCrafting(){
-        if(isEnabled() && module().getBoolean("enchanted-golden-apple-crafting")){
-            if(Bukkit.getRecipesFor(ENCHANTED_GOLDEN_APPLE.newInstance()).size() > 0) return;
+    private void registerCrafting() {
+        if (isEnabled() && module().getBoolean("enchanted-golden-apple-crafting")) {
+            if (Bukkit.getRecipesFor(ENCHANTED_GOLDEN_APPLE.newInstance()).size() > 0) return;
             Bukkit.addRecipe(enchantedAppleRecipe);
             Messenger.debug("Added napple recipe");
         }
     }
 
     @EventHandler(priority = EventPriority.HIGH)
-    public void onPrepareItemCraft(PrepareItemCraftEvent e){
+    public void onPrepareItemCraft(PrepareItemCraftEvent e) {
         ItemStack item = e.getInventory().getResult();
-        if(item == null)
+        if (item == null)
             return; // This should never ever ever ever run. If it does then you probably screwed something up.
 
-        if(ENCHANTED_GOLDEN_APPLE.isSame(item)){
+        if (ENCHANTED_GOLDEN_APPLE.isSame(item)) {
 
             World world = e.getView().getPlayer().getWorld();
 
-            if(isSettingEnabled("no-conflict-mode")) return;
+            if (isSettingEnabled("no-conflict-mode")) return;
 
-            if(!isEnabled(world))
+            if (!isEnabled(world))
                 e.getInventory().setResult(null);
-            else if(isEnabled(world) && !isSettingEnabled("enchanted-golden-apple-crafting"))
+            else if (isEnabled(world) && !isSettingEnabled("enchanted-golden-apple-crafting"))
                 e.getInventory().setResult(null);
         }
     }
 
     @EventHandler(priority = EventPriority.HIGH)
-    public void onItemConsume(PlayerItemConsumeEvent e){
-        if(e.isCancelled()) return; // Don't do anything if another plugin cancelled the event
+    public void onItemConsume(PlayerItemConsumeEvent e) {
+        if (e.isCancelled()) return; // Don't do anything if another plugin cancelled the event
 
         final Player p = e.getPlayer();
 
-        if(!isEnabled(p.getWorld()) || !isSettingEnabled("old-potion-effects")) return;
+        if (!isEnabled(p.getWorld()) || !isSettingEnabled("old-potion-effects")) return;
 
         ItemStack item = e.getItem();
         final Material consumedMaterial = item.getType();
 
-        if(consumedMaterial != Material.GOLDEN_APPLE &&
+        if (consumedMaterial != Material.GOLDEN_APPLE &&
                 !ENCHANTED_GOLDEN_APPLE.isSame(e.getItem())) return;
 
         e.setCancelled(true);
@@ -115,32 +115,33 @@ public class ModuleGoldenApple extends Module {
         // Check if the cooldown has expired yet
         lastEaten.putIfAbsent(p.getUniqueId(), new LastEaten());
 
-        if(cooldown.isOnCooldown(item, lastEaten.get(p.getUniqueId())))
-        {
+        if (cooldown.isOnCooldown(item, lastEaten.get(p.getUniqueId()))) {
             long basecd = consumedMaterial == Material.GOLDEN_APPLE ? cooldown.normal : cooldown.enchanted;
-    
+
             LastEaten lastEaten = this.lastEaten.get(p.getUniqueId());
-    
-            Instant currentcd = consumedMaterial == Material.GOLDEN_APPLE ?
+
+            Instant current = consumedMaterial == Material.GOLDEN_APPLE ?
                     lastEaten.lastNormalEaten :
                     lastEaten.lastEnchantedEaten;
-            
-            if(cooldown.sharedCooldown && lastEaten.getNewestEatTime().isPresent())
-                currentcd = lastEaten.getNewestEatTime().get();
 
-            long seconds = basecd - (Instant.now().getEpochSecond() - currentcd.getEpochSecond());
-            
+            if (cooldown.sharedCooldown && lastEaten.getNewestEatTime().isPresent())
+                current = lastEaten.getNewestEatTime().get();
+
+            long seconds = basecd - (Instant.now().getEpochSecond() - current.getEpochSecond());
+
             String which = consumedMaterial == Material.GOLDEN_APPLE ? "normal" : "enchanted";
 
-            String msg = module().getString("cooldown.message-" + which,
-                    "&ePlease wait %seconds% seconds to eat the golden apple again.")
-                    .replace("%seconds%", String.valueOf(seconds));
-            
-            Messenger.send(e.getPlayer(), msg);
-            
+            String msg = module().getString("cooldown.message-" + which);
+
+            if (msg != null && !msg.isEmpty()) {
+                msg = msg.replace("%seconds%", String.valueOf(seconds));
+
+                Messenger.send(e.getPlayer(), msg);
+            }
+
             return;
         }
-        
+
         lastEaten.get(p.getUniqueId()).setForItem(item);
 
         final ItemStack originalItem = e.getItem();
@@ -150,27 +151,27 @@ public class ModuleGoldenApple extends Module {
         int foodLevel = Math.min(p.getFoodLevel() + 4, 20);
         p.setFoodLevel(foodLevel);
 
-        if(p.getGameMode() != GameMode.CREATIVE) item.setAmount(item.getAmount() - 1);
+        if (p.getGameMode() != GameMode.CREATIVE) item.setAmount(item.getAmount() - 1);
 
         // Gapple and Napple saturation is 9.6
         float saturation = p.getSaturation() + 9.6f;
         // "The total saturation never gets higher than the total number of hunger points"
-        if(saturation > foodLevel)
+        if (saturation > foodLevel)
             saturation = foodLevel;
 
         p.setSaturation(saturation);
 
-        if(ENCHANTED_GOLDEN_APPLE.isSame(item)) applyEffects(p, enchantedGoldenAppleEffects);
+        if (ENCHANTED_GOLDEN_APPLE.isSame(item)) applyEffects(p, enchantedGoldenAppleEffects);
         else applyEffects(p, goldenAppleEffects);
 
-        if(item.getAmount() <= 0) item = null;
+        if (item.getAmount() <= 0) item = null;
 
         ItemStack mainHand = inv.getItemInMainHand();
         ItemStack offHand = inv.getItemInOffHand();
 
-        if(mainHand.equals(originalItem)) inv.setItemInMainHand(item);
-        else if(offHand.equals(originalItem)) inv.setItemInOffHand(item);
-        else if(mainHand.getType() == Material.GOLDEN_APPLE || ENCHANTED_GOLDEN_APPLE.isSame(mainHand))
+        if (mainHand.equals(originalItem)) inv.setItemInMainHand(item);
+        else if (offHand.equals(originalItem)) inv.setItemInOffHand(item);
+        else if (mainHand.getType() == Material.GOLDEN_APPLE || ENCHANTED_GOLDEN_APPLE.isSame(mainHand))
             inv.setItemInMainHand(item);
         // The bug occurs here, so we must check which hand has the apples
         // A player can't eat food in the offhand if there is any in the main hand
@@ -186,22 +187,22 @@ public class ModuleGoldenApple extends Module {
         PlayerStatisticIncrementEvent psie = new PlayerStatisticIncrementEvent(p, Statistic.USE_ITEM, initialValue, initialValue + 1, consumedMaterial);
         Bukkit.getServer().getPluginManager().callEvent(psie);
 
-        try{
+        try {
             NamespacedKey nsk = NamespacedKey.minecraft("husbandry/balanced_diet");
             Advancement advancement = Bukkit.getAdvancement(nsk);
 
             // Award advancement criterion for having eaten gapple, as incrementing statistic or calling event doesn't seem to
-            if(advancement != null)
+            if (advancement != null)
                 p.getAdvancementProgress(advancement).awardCriteria(consumedMaterial.name().toLowerCase());
-        } catch(NoClassDefFoundError ignored){
+        } catch (NoClassDefFoundError ignored) {
         } // Pre 1.12 does not have advancements
     }
 
-    private List<PotionEffect> getPotionEffects(String apple){
+    private List<PotionEffect> getPotionEffects(String apple) {
         List<PotionEffect> appleEffects = new ArrayList<>();
 
         ConfigurationSection sect = module().getConfigurationSection(apple + "-effects");
-        for(String key : sect.getKeys(false)){
+        for (String key : sect.getKeys(false)) {
             int duration = sect.getInt(key + ".duration");
             int amplifier = sect.getInt(key + ".amplifier");
 
@@ -214,15 +215,15 @@ public class ModuleGoldenApple extends Module {
         return appleEffects;
     }
 
-    private void applyEffects(LivingEntity target, List<PotionEffect> effects){
-        for(PotionEffect effect : effects){
+    private void applyEffects(LivingEntity target, List<PotionEffect> effects) {
+        for (PotionEffect effect : effects) {
             OptionalInt maxActiveAmplifier = target.getActivePotionEffects().stream()
                     .filter(potionEffect -> potionEffect.getType() == effect.getType())
                     .mapToInt(PotionEffect::getAmplifier)
                     .max();
 
             // the active one is stronger, so do not apply the weaker one
-            if(maxActiveAmplifier.orElse(-1) > effect.getAmplifier()) continue;
+            if (maxActiveAmplifier.orElse(-1) > effect.getAmplifier()) continue;
 
             // remove it, as the active one is weaker
             maxActiveAmplifier.ifPresent(ignored -> target.removePotionEffect(effect.getType()));
@@ -232,25 +233,25 @@ public class ModuleGoldenApple extends Module {
     }
 
     @EventHandler
-    public void onPlayerQuit(PlayerQuitEvent e){
-        if(lastEaten != null) lastEaten.remove(e.getPlayer().getUniqueId());
+    public void onPlayerQuit(PlayerQuitEvent e) {
+        if (lastEaten != null) lastEaten.remove(e.getPlayer().getUniqueId());
     }
 
     private static class LastEaten {
         private Instant lastNormalEaten;
         private Instant lastEnchantedEaten;
 
-        private Optional<Instant> getForItem(ItemStack item){
+        private Optional<Instant> getForItem(ItemStack item) {
             return ENCHANTED_GOLDEN_APPLE.isSame(item)
                     ? Optional.ofNullable(lastEnchantedEaten)
                     : Optional.ofNullable(lastNormalEaten);
         }
 
-        private Optional<Instant> getNewestEatTime(){
-            if(lastEnchantedEaten == null){
+        private Optional<Instant> getNewestEatTime() {
+            if (lastEnchantedEaten == null) {
                 return Optional.ofNullable(lastNormalEaten);
             }
-            if(lastNormalEaten == null){
+            if (lastNormalEaten == null) {
                 return Optional.of(lastEnchantedEaten);
             }
             return Optional.of(
@@ -258,8 +259,8 @@ public class ModuleGoldenApple extends Module {
             );
         }
 
-        private void setForItem(ItemStack item){
-            if(ENCHANTED_GOLDEN_APPLE.isSame(item)){
+        private void setForItem(ItemStack item) {
+            if (ENCHANTED_GOLDEN_APPLE.isSame(item)) {
                 lastEnchantedEaten = Instant.now();
             } else {
                 lastNormalEaten = Instant.now();
@@ -272,17 +273,17 @@ public class ModuleGoldenApple extends Module {
         private final long enchanted;
         private final boolean sharedCooldown;
 
-        Cooldown(long normal, long enchanted, boolean sharedCooldown){
+        Cooldown(long normal, long enchanted, boolean sharedCooldown) {
             this.normal = normal;
             this.enchanted = enchanted;
             this.sharedCooldown = sharedCooldown;
         }
 
-        private long getCooldownForItem(ItemStack item){
+        private long getCooldownForItem(ItemStack item) {
             return ENCHANTED_GOLDEN_APPLE.isSame(item) ? enchanted : normal;
         }
 
-        boolean isOnCooldown(ItemStack item, LastEaten lastEaten){
+        boolean isOnCooldown(ItemStack item, LastEaten lastEaten) {
             return (sharedCooldown ? lastEaten.getNewestEatTime() : lastEaten.getForItem(item))
                     .map(it -> ChronoUnit.SECONDS.between(it, Instant.now()))
                     .map(it -> it < getCooldownForItem(item))

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleGoldenApple.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleGoldenApple.java
@@ -125,8 +125,8 @@ public class ModuleGoldenApple extends Module {
             long seconds = basecd - (Instant.now().getEpochSecond() - currentcd.getEpochSecond());
             
             String which = consumedMaterial == Material.GOLDEN_APPLE ?
-                    "old-golden-apples.cooldown.message-enchanted" :
-                    "old-golden-apples.cooldown.message-normal";
+                    "old-golden-apples.cooldown.message-normal" :
+                    "old-golden-apples.cooldown.message-enchanted";
 
             String msg = plugin.getConfig().getString(which,
                     "&ePlease wait %seconds% seconds to eat the golden apple again.")

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleGoldenApple.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleGoldenApple.java
@@ -121,14 +121,12 @@ public class ModuleGoldenApple extends Module {
             Instant currentcd = consumedMaterial == Material.GOLDEN_APPLE ?
                     lastEaten.get(p.getUniqueId()).lastNormalEaten :
                     lastEaten.get(p.getUniqueId()).lastEnchantedEaten;
-            
+
             long seconds = basecd - (Instant.now().getEpochSecond() - currentcd.getEpochSecond());
             
-            String which = consumedMaterial == Material.GOLDEN_APPLE ?
-                    "old-golden-apples.cooldown.message-normal" :
-                    "old-golden-apples.cooldown.message-enchanted";
+            String which = consumedMaterial == Material.GOLDEN_APPLE ? "normal" : "enchanted";
 
-            String msg = plugin.getConfig().getString(which,
+            String msg = module().getString("cooldown.message-" + which,
                     "&ePlease wait %seconds% seconds to eat the golden apple again.")
                     .replace("%seconds%", String.valueOf(seconds));
             

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -183,8 +183,10 @@ old-golden-apples:
   cooldown:
     # The cooldown for normal golden apples
     normal: 0
+    message-normal: "&ePlease wait %seconds% seconds to eat the golden apple again."
     # The cooldown for enchanted golden apples
     enchanted: 0
+    message-enchanted: "&ePlease wait %seconds% seconds to eat the enchanted golden apple again."
     # Whether the two apple types share a cooldown.
     # If this is true:
     #   1. Eating any apple resets both cooldowns

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -183,10 +183,12 @@ old-golden-apples:
   cooldown:
     # The cooldown for normal golden apples
     normal: 0
-    message-normal: "&ePlease wait %seconds% seconds to eat the golden apple again."
+    # Message when user tries to eat golden apple during cooldown. Leave empty to disable.
+    message-normal: "&ePlease wait %seconds%s before eating another golden apple."
     # The cooldown for enchanted golden apples
     enchanted: 0
-    message-enchanted: "&ePlease wait %seconds% seconds to eat the enchanted golden apple again."
+    # Message when user tries to eat enchanted golden apple during cooldown. Leave empty to disable.
+    message-enchanted: "&ePlease wait %seconds%s before eating another enchanted golden apple."
     # Whether the two apple types share a cooldown.
     # If this is true:
     #   1. Eating any apple resets both cooldowns
@@ -537,4 +539,4 @@ debug:
   enabled: false
 
 # DO NOT CHANGE THIS NUMBER AS IT WILL RESET YOUR CONFIG
-config-version: 50
+config-version: 53


### PR DESCRIPTION
Attempt to implement the #484 enhancement.

Added cooldown messages to know how much time (seconds) are left for player to be able to eat normal/enchanted golden apple.
The code is functional and has been tested out, though perhaps not implemented in the best way, there might be some changes later.

Perhaps it would be good to implement it to show minutes (and maybe hours) for longer cooldowns, though I haven't found a reliable way to do so.