### PR TITLE
Try to fix random knockback

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModulePlayerKnockback.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModulePlayerKnockback.java
@@ -59,7 +59,7 @@ public class ModulePlayerKnockback extends Module {
 
     // Vanilla does its own knockback, so we need to set it again.
     // priority = lowest because we are ignoring the existing velocity, which could break other plugins
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerVelocityEvent(PlayerVelocityEvent event) {
         final UUID uuid = event.getPlayer().getUniqueId();
         if (!playerKnockbackHashMap.containsKey(uuid)) return;


### PR DESCRIPTION
Attempt to fix https://github.com/kernitus/BukkitOldCombatMechanics/issues/528

Untested if it actually fixes it, but it should stop plugins that cancel the knockback event on the LOWEST priority from breaking OCM.