### PR TITLE
Whitelist mcnative packets as they intentionally send them

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/PacketHelper.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/PacketHelper.java
@@ -24,6 +24,21 @@ public class PacketHelper {
     }
 
     /**
+     * Some plugins send their own packets for various reasons. While this might cause incompatibilties with a variety
+     * of other plugins including OCM, we can't change what other people do. The plugins whitelisted here intentionally
+     * send such packets and we should forward them. Any issues that might arise from it are out of scope of OCM support.
+     *
+     * @param object the packet object to check
+     * @return true if the packet is allowed to proceed even if it is not an NMS packet
+     */
+    public static boolean isWhitelistedNonNmsPacket(Object object){
+        if(object == null){
+            return false;
+        }
+        return object.getClass().getName().startsWith("org.mcnative.runtime.api.protocol.packet.type");
+    }
+
+    /**
      * Wraps a nms packet in a trivial {@link ImmutablePacket}.
      *
      * @param nmsPacket the nms packet to wrap

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/mitm/PacketInjector.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/mitm/PacketInjector.java
@@ -159,6 +159,12 @@ class PacketInjector extends ChannelDuplexHandler {
         }
 
         if(!PacketHelper.isNmsPacket(packet)){
+            // forward allowed packets
+            if(PacketHelper.isWhitelistedNonNmsPacket(packet)){
+                super.write(channelHandlerContext, packet, channelPromise);
+                return;
+            }
+
             debug("Received a packet THAT IS NO PACKET: " + packet.getClass() + " " + packet);
             return;
         }


### PR DESCRIPTION
Sending something that is not an NMS packet normally is a bug, but the whitelisted plugins does it intentionally. We should not interfere with it, but any issues that might arise are out of scope for this project.

Closes: #556 