### PR TITLE
Allow option to disable message prefixes

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/Messenger.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/Messenger.java
@@ -63,14 +63,14 @@ public class Messenger {
     }
 
     public static void sendNormalMessage(CommandSender sender, String message, Object... args) {
-        if (Config.getConfig().getBoolean("show-prefix", true))
+        if (plugin.getConfig().getBoolean("show-prefix", true))
             sendWithPrefix(sender, message, "&6[OCM]&r", args);
         else
             sendWithPrefix(sender, message, "&r", args);
     }
 
     public static void sendDebugMessage(CommandSender sender, String message, Object... args) {
-        if (Config.getConfig().getBoolean("show-prefix", true))
+        if (plugin.getConfig().getBoolean("show-prefix", true))
             sendWithPrefix(sender, message, "&1[Debug]&r", args);
         else
             sendWithPrefix(sender, message, "&r", args);

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/Messenger.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/Messenger.java
@@ -62,12 +62,18 @@ public class Messenger {
         send(sender, prefix + " " + message, args);
     }
 
-    public static void sendNormalMessage(CommandSender sender, String message, Object... args){
-        sendWithPrefix(sender, message, "&6[OCM]&r", args);
+    public static void sendNormalMessage(CommandSender sender, String message, Object... args) {
+        if (Config.getConfig().getBoolean("show-prefix", true))
+            sendWithPrefix(sender, message, "&6[OCM]&r", args);
+        else
+            sendWithPrefix(sender, message, "&r", args);
     }
 
-    public static void sendDebugMessage(CommandSender sender, String message, Object... args){
-        sendWithPrefix(sender, message, "&1[Debug]&r", args);
+    public static void sendDebugMessage(CommandSender sender, String message, Object... args) {
+        if (Config.getConfig().getBoolean("show-prefix", true))
+            sendWithPrefix(sender, message, "&1[Debug]&r", args);
+        else
+            sendWithPrefix(sender, message, "&r", args);
     }
 
     public static void debug(String message, Throwable throwable) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -557,5 +557,8 @@ support:
 debug:
   enabled: false
 
+# This can be used to disable the [OCM] at the beginning of messages sent by the plugin
+show-prefix: true
+
 # DO NOT CHANGE THIS NUMBER AS IT WILL RESET YOUR CONFIG
-config-version: 53
+config-version: 54


### PR DESCRIPTION
This gives players the option remove the prefixes at the beginning of messages.