### PR TITLE
Allow any non-NMS packet through the pipeline

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/PacketHelper.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/PacketHelper.java
@@ -24,21 +24,6 @@ public class PacketHelper {
     }
 
     /**
-     * Some plugins send their own packets for various reasons. While this might cause incompatibilties with a variety
-     * of other plugins including OCM, we can't change what other people do. The plugins whitelisted here intentionally
-     * send such packets and we should forward them. Any issues that might arise from it are out of scope of OCM support.
-     *
-     * @param object the packet object to check
-     * @return true if the packet is allowed to proceed even if it is not an NMS packet
-     */
-    public static boolean isWhitelistedNonNmsPacket(Object object){
-        if(object == null){
-            return false;
-        }
-        return object.getClass().getName().startsWith("org.mcnative.runtime.api.protocol.packet.type");
-    }
-
-    /**
      * Wraps a nms packet in a trivial {@link ImmutablePacket}.
      *
      * @param nmsPacket the nms packet to wrap

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/mitm/PacketInjector.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/mitm/PacketInjector.java
@@ -159,13 +159,7 @@ class PacketInjector extends ChannelDuplexHandler {
         }
 
         if(!PacketHelper.isNmsPacket(packet)){
-            // forward allowed packets
-            if(PacketHelper.isWhitelistedNonNmsPacket(packet)){
-                super.write(channelHandlerContext, packet, channelPromise);
-                return;
-            }
-
-            debug("Received a packet THAT IS NO PACKET: " + packet.getClass() + " " + packet);
+            super.write(channelHandlerContext, packet, channelPromise);
             return;
         }
 


### PR DESCRIPTION
This fixes PacketEvents 2.0 compatibility.

It is perfectly legal to send a byte buffer through the netty pipeline.  PacketEvents 2.0 is designed to use byte buffers over NMS objects for performance and compatiblity reasons.  It's twice as fast to not use reflection to read packets.  Additionally, there's few incompatibilities with server jars changing reflection.  The code is also cleaner, and compatible with Bungeecord, Velocity, and Bukkit.  While packetevents 2.0 could re-encode the packet.  ViaVersion handles byte buffers fine, and vanilla's encoder will ignore packets that aren't NMS objects.  Pushing it through the pipeline.