### PR TITLE
Only set nametag visibility if it is valid

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/team/V17TeamPacket.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/packet/team/V17TeamPacket.java
@@ -254,11 +254,14 @@ public class V17TeamPacket extends TeamPacket {
                     team,
                     (packOptionData & 0b10) != 0
             );
-            Reflector.invokeMethod(
-                    ScoreboardTeamMethods.getInstance().setNameTagVisibility,
-                    team,
-                    OptionalDataClassHelper.parseNameTagVisibility(nameTagVisibility)
-            );
+            Object parsedNameTagVisibility = OptionalDataClassHelper.parseNameTagVisibility(nameTagVisibility);
+            if (parsedNameTagVisibility != null) {
+                Reflector.invokeMethod(
+                        ScoreboardTeamMethods.getInstance().setNameTagVisibility,
+                        team,
+                        parsedNameTagVisibility
+                );
+            }
             Reflector.invokeMethod(
                     ScoreboardTeamMethods.getInstance().setCollisionRule,
                     team,


### PR DESCRIPTION
Some plugins apparently create UPDATE packets with an empty String for the collision rule and nametag visibility. I can't see how that is valid and we can not properly recreate it using the data class constructor, so fall back to the default visibility instead.

Closes #642.