### PR TITLE
Fix comment about armour damage calculation

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleOldArmourStrength.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleOldArmourStrength.java
@@ -33,7 +33,7 @@ public class ModuleOldArmourStrength extends OCMModule {
     @SuppressWarnings("deprecation")
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityDamage(EntityDamageEvent e) {
-        // 1.8 NMS: Damage = 25 / (damage after blocking * (25 - total armour strength))
+        // 1.8 NMS: Damage = (damage after blocking * (25 - total armour strength)) / 25
         if (!(e.getEntity() instanceof LivingEntity)) return;
 
         final LivingEntity damagedEntity = (LivingEntity) e.getEntity();


### PR DESCRIPTION
1.8.8 NMS

```java
    protected float applyArmorModifier(DamageSource damagesource, float f) {
        if (!damagesource.ignoresArmor()) {
            int i = 25 - this.br();
            float f1 = f * (float) i;

            // this.damageArmor(f); // CraftBukkit - Moved into d(DamageSource, float)
            f = f1 / 25.0F;
        }

        return f;
    }
```