### PR TITLE
fix NullPointer when sending custom sounds

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleAttackSounds.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleAttackSounds.java
@@ -66,6 +66,12 @@ public class ModuleAttackSounds extends OCMModule {
             try {
                 final PacketContainer packetContainer = packetEvent.getPacket();
                 final Sound sound = packetContainer.getSoundEffects().read(0);
+                
+                //fix NullpointerException when sending a custom sound 
+                if (sound == null) {
+                    return;
+                }
+                
                 final String soundName = sound.toString(); // Works for both string and namespaced key
 
                 if (blockedSounds.contains(soundName)) {


### PR DESCRIPTION
Texturepacks allow for sending custom sounds. But when sending custom sounds, the line... final String soundName = sound.toString();
...will throw a NullPointer due to the sound not being present in the Sound Enumeration. This check basicly just prevents this exception from happening.