### PR TITLE
Update ModuleSwordBlocking.java

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleSwordBlocking.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleSwordBlocking.java
@@ -83,6 +83,8 @@ public class ModuleSwordBlocking extends OCMModule {
         if (action == Action.RIGHT_CLICK_BLOCK && e.getHand() == EquipmentSlot.HAND) return;
         if (e.isBlockInHand()){
             if(lastInteractedBlocks != null)
+                if (e.getClickedBlock() == null) return;
+
                 lastInteractedBlocks.put(e.getClickedBlock().getLocation(), player.getUniqueId());
             return; // Handle failed block place in separate listener
         }

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleSwordBlocking.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleSwordBlocking.java
@@ -10,6 +10,7 @@ import kernitus.plugin.OldCombatMechanics.utilities.reflection.Reflector;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleSwordBlocking.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleSwordBlocking.java
@@ -82,10 +82,12 @@ public class ModuleSwordBlocking extends OCMModule {
         // TODO right-clicking on a mob also only fires one hand
         if (action == Action.RIGHT_CLICK_BLOCK && e.getHand() == EquipmentSlot.HAND) return;
         if (e.isBlockInHand()){
-            if(lastInteractedBlocks != null)
-                if (e.getClickedBlock() == null) return;
+            if(lastInteractedBlocks != null) {
+                Block targetBlock = player.getTargetBlock(null, 5);
+                if (targetBlock == null) return; 
 
-                lastInteractedBlocks.put(e.getClickedBlock().getLocation(), player.getUniqueId());
+                lastInteractedBlocks.put(targetBlock.getLocation(), player.getUniqueId());
+            }
             return; // Handle failed block place in separate listener
         }
 


### PR DESCRIPTION
Add check if PlayerInteractEvent.getClickedBlock() is null

```
[23:24:32 ERROR]: Could not pass event PlayerInteractEvent to OldCombatMechanics v2.0.3
org.bukkit.event.EventException: null
        at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:72) ~[patched_1.12.2.jar:git-Paper-1620]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:78) ~[patched_1.12.2.jar:git-Paper-1620]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62) ~[patched_1.12.2.jar:git-Paper-1620]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:513) ~[patched_1.12.2.jar:git-Paper-1620]
        at org.bukkit.craftbukkit.v1_12_R1.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:236) ~[patched_1.12.2.jar:git-Paper-1620]
        at org.bukkit.craftbukkit.v1_12_R1.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:203) ~[patched_1.12.2.jar:git-Paper-1620]
        at org.bukkit.craftbukkit.v1_12_R1.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:199) ~[patched_1.12.2.jar:git-Paper-1620]
        at net.minecraft.server.v1_12_R1.PlayerConnection.a(PlayerConnection.java:1049) ~[patched_1.12.2.jar:git-Paper-1620]
        at net.minecraft.server.v1_12_R1.PacketPlayInBlockPlace.a(PacketPlayInBlockPlace.java:26) ~[patched_1.12.2.jar:git-Paper-1620]
        at net.minecraft.server.v1_12_R1.PacketPlayInBlockPlace.a(PacketPlayInBlockPlace.java:5) ~[patched_1.12.2.jar:git-Paper-1620]
        at net.minecraft.server.v1_12_R1.PlayerConnectionUtils.lambda$ensureMainThread$0(PlayerConnectionUtils.java:14) ~[patched_1.12.2.jar:git-Paper-1620]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
        at net.minecraft.server.v1_12_R1.SystemUtils.a(SourceFile:46) ~[patched_1.12.2.jar:git-Paper-1620]
        at net.minecraft.server.v1_12_R1.MinecraftServer.D(MinecraftServer.java:850) ~[patched_1.12.2.jar:git-Paper-1620]
        at net.minecraft.server.v1_12_R1.DedicatedServer.D(DedicatedServer.java:423) ~[patched_1.12.2.jar:git-Paper-1620]
        at net.minecraft.server.v1_12_R1.MinecraftServer.C(MinecraftServer.java:774) ~[patched_1.12.2.jar:git-Paper-1620]
        at net.minecraft.server.v1_12_R1.MinecraftServer.run(MinecraftServer.java:666) ~[patched_1.12.2.jar:git-Paper-1620]
        at java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "org.bukkit.block.Block.getLocation()" because the return value of "org.bukkit.event.player.PlayerInteractEvent.getClickedBlock()" is null
        at kernitus.plugin.OldCombatMechanics.module.ModuleSwordBlocking.onRightClick(ModuleSwordBlocking.java:86) ~[?:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor168.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:70) ~[patched_1.12.2.jar:git-Paper-1620]
        ... 18 more
```