### PR TITLE
Fix saving negative last damage to the entity

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/damage/EntityDamageByEntityListener.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/damage/EntityDamageByEntityListener.java
@@ -212,7 +212,7 @@ public class EntityDamageByEntityListener extends OCMModule {
     }
 
     private double checkOverdamage(LivingEntity livingDamagee, EntityDamageEvent event, double newDamage) {
-        final double newLastDamage = newDamage;
+        final double newLastDamage = Math.max(newDamage, 0);
 
         if ((float) livingDamagee.getNoDamageTicks() > (float) livingDamagee.getMaximumNoDamageTicks() / 2.0F) {
             // Last damage was either set to correct value above in this listener, or we're using the server's value
@@ -228,7 +228,7 @@ public class EntityDamageByEntityListener extends OCMModule {
 
             debug("Overdamage: " + newDamage + " - " + lastDamage);
             // We must subtract previous damage from new weapon damage for this attack
-            newDamage -= livingDamagee.getLastDamage();
+            newDamage = Math.max(newDamage -livingDamagee.getLastDamage(), 0);
 
             debug("Last damage " + lastDamage + " new damage: " + newLastDamage + " applied: " + newDamage
                     + " ticks: " + livingDamagee.getNoDamageTicks() + " /" + livingDamagee.getMaximumNoDamageTicks()


### PR DESCRIPTION
## Description 
Minecraft uses the last damage stored on an entity to modify incoming damage that happens during the immunity tick with the formula `real-damage=input-damage - last damage`. When the last damage is negative the amount adds to the real damage taken and bypasses all damage reduction items like armor and effects like resistance.

## Steps to Reproduce

Attack a player in full diamond armor with a sharpness 5 diamond sword while using a weakness 2 potion effect. Continue to attack the player until the potion effect expires. The player may suddenly die instead of taking normal diamond sword damage.

## Config
```
# This Source Code Form is subject to the terms of the Mozilla Public
# License, v. 2.0. If a copy of the MPL was not distributed with this
# file, You can obtain one at https://mozilla.org/MPL/2.0/.

# ############# OldCombatMechanics Plugin by kernitus and Rayzr522 ##########
#                                                                           #
# Bukkit Page: http://dev.bukkit.org/bukkit-plugins/oldcombatmechanics/     #
# Spigot Page: https://www.spigotmc.org/resources/oldcombatmechanics.19510/ #
# GitHub Page: https://github.com/kernitus/BukkitOldCombatMechanics/        #
#                                                                           #
# ###########################################################################

modesets:
  # Modesets are lists of modules that are enabled for a player in that mode.
  # Modules not listed in any modeset are assumed to always be available.
  # You can create, remove, and rename as many modesets as you like by modifying the list below.
  # When in PvP, the modeset of the attacker is checked first.
  # If not PvP, the modeset of the defending entity is checked.
  # Of course, the module must also be enabled in its own config section.
  # Sample below has modules enabled for "old" combat modeset and disabled for "new" combat modeset
  # PlaceholderAPI: %ocm_modeset%
  old:
    - "disable-attack-cooldown"
    - "disable-sword-sweep"
    - "disable-offhand"
    - "old-tool-damage"
    - "sword-blocking"
    - "shield-damage-reduction"
    - "old-golden-apples"
    - "old-player-knockback"
    - "old-player-regen"
    - "old-armour-strength"
    - "old-potion-effects"
    - "old-critical-hits"
    - "attack-frequency"
  new: [ ]

worlds:
  # These are the modesets available in each world.
  # If player has no modeset when moving worlds they'll be assigned first mode in list,
  # unless the mode from the world they are coming from is also available in the new world.
  # Worlds not specified below will have all modesets available.
  world: [ "old", "new" ]
  world_nether: [ "old", "new" ]
  world_the_end: [ "old", "new" ]
  # old_world: ["old"]
  # brave_new_world: ["new"]

mode-messages:
  # Messages used when changing player mode
  # To disable any message, leave the corresponding string empty (e.g., mode-status: "").
  # This applies to all messages in the configuration.
  mode-status: "&bYour current modeset is: &7%s"
  message-usage: "&eYou can use &c/ocm mode <modeset> [player] &eto change modeset"
  invalid-modeset: "&cPlease specify a valid modeset!"
  invalid-player: "&cPlease specify a valid player!"
  mode-set: "&2Set modeset to &7%s"

# ########################
# COMBAT MODULE SETTINGS
# ########################

disable-attack-cooldown:
  # This is to disable the attack cooldown
  enabled: true
  # What to set the attack speed to. Default for 1.9 is 4, at least 40 is needed for no cooldown.
  generic-attack-speed: 40

attack-frequency:
  # Allows changing the player invulnerability between hits
  enabled: true
  # The hit delay to apply. Default for 1.9+ is 20 ticks (1 second)
  playerDelay: 18
  mobDelay: 16

old-tool-damage:
  # This is to set the tool damage as in pre-1.9
  # IMPORTANT: Also enable disable-sword-sweep module or sweeps will have the damage value of the weapon in hand
  # NOTE: this will modify the damage, however the item tooltip will still show the 1.9+ damage
  enabled: true
  # Use old sharpness calculations, i.e. each level adds 1.25 damage
  # In 1.9+, sharpness adds 1 + 0.5 * level damage
  old-sharpness: true
  # Damage values shown in 1.9 representation (actual damage)
  # In 1.8 the damage tooltip value would be added to 1 'base damage', yielding the values below
  damages:
    # Axe damages
    GOLD_AXE: 4
    WOOD_AXE: 4
    STONE_AXE: 5
    IRON_AXE: 6
    DIAMOND_AXE: 7
    NETHERITE_AXE: 8
    # Shovel damages
    GOLD_SPADE: 2
    WOOD_SPADE: 2
    STONE_SPADE: 3
    IRON_SPADE: 4
    DIAMOND_SPADE: 5
    NETHERITE_SPADE: 6
    # Sword damages
    GOLD_SWORD: 5
    WOOD_SWORD: 5
    STONE_SWORD: 6
    IRON_SWORD: 7
    DIAMOND_SWORD: 8
    NETHERITE_SWORD: 9
    # Pickaxe damages
    GOLD_PICKAXE: 3
    WOOD_PICKAXE: 3
    STONE_PICKAXE: 4
    IRON_PICKAXE: 5
    DIAMOND_PICKAXE: 6
    NETHERITE_PICKAXE: 7
    # Hoe damages
    GOLD_HOE: 1
    WOOD_HOE: 1
    STONE_HOE: 1
    IRON_HOE: 1
    DIAMOND_HOE: 1
    NETHERITE_HOE: 1

old-critical-hits:
  # Makes critical hits work like in 1.8
  # With a critical hit, the damage will be multiplied by 1.5
  # In 1.9, the user must also not be sprinting for it to be a crit
  enabled: true
  world: [ ]
  # What the damage, after applying potions effects, is multiplied by
  multiplier: 1.5
  # Whether to allow crits while sprinting. 1.8: true, 1.9: false
  allow-sprinting: true

old-player-regen:
  # This is to make players' regeneration act mostly like it did in pre-1.9
  # Based on https://minecraft.gamepedia.com/Hunger?oldid=948685
  enabled: true
  # How often a player should regenerate health, in milliseconds (In 1.8: 4 seconds)
  # The foodTickerTimer might not be perfectly accurate so we give it ~10ms of leeway
  interval: 3990
  # How many half-hearts the player should heal by, every seconds specified above
  amount: 1
  # How much exhaustion the player should get from healing. In 1.8: 3    In 1.9: 4    In 1.11: 6
  # If, after adding this, Minecraft finds the value is above 4, it subtracts 4
  # and either reduces saturation or, if saturation is 0, reduces food level by 1 (1/2 a stick)
  exhaustion: 3

# ########################
# ARMOUR
# ########################

old-armour-strength:
  # This is to make armour calculations like in 1.8
  # Based on this: https://minecraft.gamepedia.com/index.php?title=Armor&oldid=909187
  enabled: true
  # Whether to introduce randomness in the calculation, as in 1.8
  randomness: true

old-armour-durability:
  # This makes armour take a constant amount of durability damage (except for explosions)
  enabled: true
  # By how much to reduce durability every attack. 1.8 default is 1
  reduction: 1

# ########################
# SWEEP, SHIELDS & BLOCKING
# ########################

shield-damage-reduction:
  # This module allows changing the damage reduction behaviour of shields
  enabled: true
  # How much damage blocking should reduce
  # Firstly, amount is subtracted, then value is multiplied by percentage
  # 1.8: (damage - 1) * 50%    1.9: damage * 33%   1.11: damage * 0%
  # Damage reduction = (damage - damageReductionAmount) * damageReductionPercentage / 100
  generalDamageReductionAmount: 1
  generalDamageReductionPercentage: 50
  # This value works the same but is exclusively for projectile damage
  # Set amount to 0 and percentage to 100 for 1.8 behaviour, i.e. arrows go through shields
  projectileDamageReductionAmount: 1
  projectileDamageReductionPercentage: 50

sword-blocking:
  # This is to allow players to block with swords again, by getting a shield while they hold right click with a sword
  enabled: true
  # How often, in ticks, OCM should check if the player is still blocking with a shield, and remove it if not
  # If this is too fast, the player will have their shield disappear before they're able to block again causing a slight delay
  # If this is too slow, players will have a shield in their hand well after they've stopped blocking
  # 20 ticks = 1 second
  restoreDelay: 40
  # Whether to require players to have oldcombatmechanics.swordblock permission to block with a sword
  use-permission: false

disable-sword-sweep:
  # This is to disable the sword sweep attack
  # With ProtocolLib, particle effect is also removed
  enabled: true

disable-sword-sweep-particles:
  # This is to disable the sword sweep attack particles
  # Requires ProtocolLib
  enabled: false

# ########################
# KNOCKBACK
# ########################

old-player-knockback:
  # This is to change knockback players receive from attacks.  Default values are as in 1.8.
  #
  # Practice servers tend to use lower knockback, for example:
  # knockback-horizontal: 0.35
  # knockback-vertical: 0.35
  # knockback-vertical-limit: 0.4
  # knockback-extra-horizontal: 0.425
  # knockback-extra-vertical: 0.085
  #
  # Minigame servers use higher vertical knockback and lower horizontal knockback, exact values are unknown.
  enabled: true
  # Horizontal knockback is reduced by 40% for every successful attack by the player, with no limit
  # Increase to make clicking more important, decrease to make it less important
  knockback-horizontal: 0.4
  # Vertical knockback is not reduced by clicking faster
  # Increase to make clicking less important, decrease to make clicking more important
  knockback-vertical: 0.4
  # Vertical knockback limit is applied after base vertical knockback
  # This limit can be exceeded by sprint hitting or knockback enchantments, from the extra vertical knockback
  knockback-vertical-limit: 0.4
  # Extra horizontal knockback is applied for each level of knockback enchant, and for sprinting
  # Increase to make sprint resetting (w-tapping) more important, decrease to make it less important
  # Increase to make clicking more important, decrease to make clicking less important
  knockback-extra-horizontal: 0.5
  # Extra vertical knockback is applied for each level of knockback enchant, and for sprinting
  # Increase to make sprint resetting (w-tapping) more important, decrease to make it less important
  # Increase to make clicking less important, decrease to make clicking more important
  knockback-extra-vertical: 0.1
  # Should knockback resistance be enabled? (e.g. netherite armour knockback resistance)
  enable-knockback-resistance: false

old-fishing-knockback:
  # This is to make the knockback of players when they get hit by a fishing bobber the same as it was in pre-1.9
  enabled: true
  # This is the damage done by the fishing rod attack
  damage: 0.0001
  # This is to cancel dragging in the entity attached to the fishing rod when reeling in, like in 1.8
  # Options: all, players, mobs, none. players allows compatibility with WorldGuard pvp-deny regions
  cancelDraggingIn: players
  # Whether to also give knockback on non-player living entities (e.g. mobs)
  knockbackNonPlayerEntities: false
  # This is the delay in milliseconds in-between rod damage, so the player hit has time to fall back down
  hitCooldown: 1000

fishing-rod-velocity:
  # In 1.9+ fishing rods go 8 blocks instead of 12 blocks
  # This is due to both gravity and initial launch speed
  # Set to true to revert back to the old calculations and gravity
  enabled: true

projectile-knockback:
  # This adds knockback and/or damage to players when they get hit by snowballs, eggs & enderpearls
  # This has been a Bukkit bug for so long people thought it was vanilla when it was patched
  enabled: true
  # This is the damage done by each projectile
  damage:
    snowball: 0.0001
    egg: 0.0001
    ender_pearl: 0.0001

# ########################
# GAPPLES & POTIONS
# ########################

old-golden-apples:
  # This is to change the behaviour / crafting of golden apples to how it was in pre-1.9
  # WARNING: If on 1.12 or above and you disable this module you must reload the server for the recipe to disappear
  enabled: true
  # Cooldown between eating the apples, in seconds
  cooldown:
    # The cooldown for normal golden apples
    # PlaceholderAPI: %ocm_gapple_cooldown%
    normal: 0
    # Message when user tries to eat golden apple during cooldown. Leave empty to disable.
    message-normal: "&ePlease wait %seconds%s before eating another golden apple."
    # The cooldown for enchanted golden apples
    # PlaceholderAPI: %ocm_napple_cooldown%
    enchanted: 0
    # Message when user tries to eat enchanted golden apple during cooldown. Leave empty to disable.
    message-enchanted: "&ePlease wait %seconds%s before eating another enchanted golden apple."
    # Whether the two apple types share a cooldown.
    # If this is true:
    #   1. Eating any apple resets both cooldowns
    #   2. Each apple type can only be eaten when its cooldown time is over
    #      This means that when you eat *any* apple you start two parallel cooldowns: One for enchanted and one
    #      for normal apples. Each type can only be eaten when its cooldown is over.
    #      Once any apple is eaten, both cooldowns are restarted, so you can not eat either type again
    #      before its full cooldown is over.
    #   3. To have the plugin treat normal and enchanted golden apples as having the same cooldown,
    #      then set the same cooldown time and enable shared mode. (This was the old mode)
    # If this is false:
    #   Eating an enchanted apple will prevent any *enchanted* apple type from being eaten before the cooldown is over
    #   Eating a normal apple will prevent any *normal* apple type from being eaten before the normal cooldown is over
    is-shared: false
  # If you want to allow enchanted golden apple crafting
  enchanted-golden-apple-crafting: true
  # Enabling this makes the potion effects gained by eating golden apples
  # and enchanted golden apples the same as it was in pre-1.9
  old-potion-effects: true
  # Potion effects for golden apples
  # Duration is in seconds
  # Amplifier is the potion level-1, so Regeneration IV would be amplifier 3
  golden-apple-effects:
    regeneration:
      duration: 5
      amplifier: 1
    absorption:
      duration: 120
      amplifier: 0
  # Potion effects for enchanted golden apples
  enchanted-golden-apple-effects:
    regeneration:
      duration: 30
      amplifier: 4
    resistance:
      duration: 300
      amplifier: 0
    fire_resistance:
      duration: 300
      amplifier: 0
    absorption:
      duration: 120
      amplifier: 0
  # Enable this if you have another plugin which adds a crafting recipe for
  # enchanted golden apples (requires server restart)
  no-conflict-mode: false

old-potion-effects:
  # This is to restore the 1.8 potion effects and duration
  enabled: true

  # DURATION: (in seconds)
  potion-durations:
    drinkable:
      regeneration: 45
      strong_regeneration: 22
      long_regeneration: 120

      swiftness: 180
      strong_swiftness: 90
      long_swiftness: 480

      fire_resistance: 180
      long_fire_resistance: 480

      poison: 45
      strong_poison: 22
      long_poison: 120

      night_vision: 180
      long_night_vision: 480

      weakness: 90
      long_weakness: 240

      strength: 180
      strong_strength: 90
      long_strength: 480

      slowness: 90
      long_slowness: 240

      leaping: 180
      strong_leaping: 90
      long_leaping: 480

      water_breathing: 180
      long_water_breathing: 480

      invisibility: 180
      long_invisibility: 480

      # 1.9+ potions. You can add more as needed.
      # Make sure to also add to splash section below.
      luck: 300

      slow_falling: 90
      long_slow_falling: 240

    splash:
      regeneration: 33
      strong_regeneration: 16
      long_regeneration: 90

      swiftness: 135
      strong_swiftness: 67
      long_swiftness: 360

      fire_resistance: 135
      long_fire_resistance: 360

      poison: 33
      strong_poison: 16
      long_poison: 90

      night_vision: 180
      long_night_vision: 480

      weakness: 90
      long_weakness: 240

      strength: 135
      strong_strength: 67
      long_strength: 360

      slowness: 67
      long_slowness: 180

      leaping: 135
      strong_leaping: 67
      long_leaping: 360

      water_breathing: 135
      long_water_breathing: 360

      invisibility: 135
      long_invisibility: 360

      # 1.9+ potions. You can add more as needed
      luck: 300

      slow_falling: 90
      long_slow_falling: 240

  # EFFECTS
  # If 'multiplier' is true value is multiplied by base tool damage. If 'addend' it is added.
  # If both true, it is first increased by 1 then multiplied (same as +xx%)
  # Strength potion
  # 1.9: I = +3; II = +6;    1.8: I = +130%; II = +260%
  strength:
    modifier: 1.3
    multiplier: true
    addend: true
  # Weakness potion
  # 1.9 value: -4   1.8 value: -0.5
  weakness:
    modifier: -0.5
    multiplier: false

# ########################
# MISCELLANEOUS
# ########################

disable-crafting:
  # Disable the crafting of specified items
  enabled: true
  # List of denied items
  denied:
    - shield
  # Show the user a message if they try to craft a blacklisted item
  showMessage: true
  message: "&cYou cannot craft that item!"

disable-offhand:
  # Disable the usage of the offhand
  # Won't affect sword-blocking module
  enabled: true
  # Whether the following list allows items or blocks them
  whitelist: true
  # List of items that should be allowed/blocked
  # Example: [diamond_sword,BOW]
  items: [ ]
  # Message to send user when denied. Set to '' to disable
  denied-message: "&cOff-hand is disabled"

old-brewing-stand:
  # Automatically refuels brewing stands
  enabled: true

no-lapis-enchantments:
  # Automatically adds lapis to enchantment tables upon opening
  enabled: false
  # Whether to only allow this for players with oldcombatmechanics.nolapis permission
  usePermission: false

disable-enderpearl-cooldown:
  # Disables enderpearl cooldown
  enabled: true
  # The cooldown, in seconds
  # PlaceholderAPI: %ocm_enderpearl_cooldown%
  cooldown: 0
  # Show the user a message if they try to use an enderpearl and the cooldown has not expired yet
  showMessage: true
  message: "&cYou must wait &7%ds&c before using an enderpearl again!"

chorus-fruit:
  # This makes the chorus fruit behaviour configurable
  enabled: false
  # The maximum distance the fruit can teleport the player. This a PER AXIS value, so this outlines a cube with
  # 2 * max-teleportation-distance as the side length
  # Vanilla default is 8.
  # Setting this to 0 disables chorus fruit teleport.
  # Setting this to a value greater than 8 MIGHT CAUSE CONFLICTS with bukkit's internal anti cheat
  # and *potentially* any other anti-cheat you use. Please make sure this is not an issue before increasing
  # this value.
  max-teleportation-distance: 8
  # Whether to prevent eating the fruit completely. This also prevents the teleportation.
  prevent-eating: false
  # The saturation value of the chorus fruit.
  # Vanilla default is 2.4
  saturation-value: 2.4
  # The hunger value of the chorus fruit.
  # Vanilla default is 4 (2 bars)
  hunger-value: 4

old-burn-delay:
  # This makes it so entities will immediately start to burn when entering fire
  enabled: false
  # How long, in ticks, entities should be on fire for after not being in direct contact anymore
  fire-ticks: 120

disable-projectile-randomness:
  # This is to remove projectile randomness while firing arrows with a bow
  # Or to remove effects of velocity when player is running and launching potions etc
  # This is actually a very old feature and has been in the game for quite some time
  enabled: false
  # What projectiles are affected e.g. arrow, splash_potion, snowball, egg, fishing_hook
  projectile-types: [ arrow ]
  # This is the threshold between projectiles' (X,Z) values before they're considered the same and straightened
  # This value is only useful for multishot. The default of 0.1 works at all but extremely shallow angles,
  # where arrows end up bunched together. Set to 1 if you want multishots to all follow the same path.
  epsilon: 0.1

disable-bow-boost:
  # This is to stop players from boosting themselves forward by hitting themselves
  # while running with a punch II arrow from their bow
  # This module simply stops them from hitting themselves with arrows entirely
  enabled: false

disable-attack-sounds:
  # Disables attack sounds that were added with 1.9+
  # Requires ProtocolLib
  enabled: false
  # The sounds that will be blocked by this module
  blocked-sound-names:
    - "ENTITY_PLAYER_ATTACK_STRONG"
    - "ENTITY_PLAYER_ATTACK_SWEEP"
    - "ENTITY_PLAYER_ATTACK_NODAMAGE"
    - "ENTITY_PLAYER_ATTACK_KNOCKBACK"
    - "ENTITY_PLAYER_ATTACK_CRIT"
    - "ENTITY_PLAYER_ATTACK_WEAK"

# ########################
# SPECIAL SETTINGS BELOW #
# ########################

message-prefix: "&6[OCM]&r"

# This is to toggle the update checker
update-checker:
  # Whether to check for updates and notify players with the oldcombatmechanics.notify permission
  enabled: true
  # Whether to automatically download an update of the plugin
  # The update is applied on the next restart/reload of the server
  # Auto update is disabled if Spigot version is below 1.18.1 and force-below-1-18-1-config-upgrade is false
  # This is to prevent accidentally resetting the config
  auto-update: true

# Whether to force config upgrade even in Spigot versions below 1.18.1
# This is not advised, as all the comments would be removed
force-below-1-18-1-config-upgrade: false

# This enables command argument completion when pressing tab
command-completer:
  enabled: true

# This enables debug messages, only enable when troubleshooting
debug:
  enabled: true

# DO NOT CHANGE THIS NUMBER AS IT WILL RESET YOUR CONFIG
config-version: 66
```
