### PR TITLE
Remove redundant overdamage

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/damage/OCMEntityDamageByEntityEvent.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/damage/OCMEntityDamageByEntityEvent.java
@@ -75,32 +75,6 @@ public class OCMEntityDamageByEntityEvent extends Event implements Cancellable {
 
         // The raw damage passed to this event is EDBE's BASE damage, which does not include armour effects or resistance etc (defence)
         this.rawDamage = rawDamage;
-
-        /*
-        Invulnerability will cause less damage if they attack with a stronger weapon while vulnerable.
-        We must detect this and account for it, instead of setting the usual base weapon damage.
-        We artificially set the last damage to 0 between events so that all hits will register,
-        however we only do this for DamageByEntity, so there could still be environmental damage (e.g. cactus).
-        */
-        if (damagee instanceof LivingEntity) {
-            final LivingEntity livingDamagee = (LivingEntity) damagee;
-            if ((float) livingDamagee.getNoDamageTicks() > (float) livingDamagee.getMaximumNoDamageTicks() / 2.0F) {
-                // NMS code also checks if current damage is higher that previous damage. However, here the event
-                // already has the difference between the two as the raw damage, and the event does not fire at all
-                // if this precondition is not met.
-
-                // Adjust for last damage being environmental sources (e.g. cactus, fall damage)
-                final double lastDamage = livingDamagee.getLastDamage();
-                this.rawDamage = rawDamage + lastDamage;
-
-                debug(livingDamagee, "Overdamaged!: " + livingDamagee.getNoDamageTicks() + "/" +
-                        livingDamagee.getMaximumNoDamageTicks() + " last: " + livingDamagee.getLastDamage());
-            } else {
-                debug(livingDamagee, "Invulnerability: " + livingDamagee.getNoDamageTicks() + "/" +
-                        livingDamagee.getMaximumNoDamageTicks() + " last: " + livingDamagee.getLastDamage());
-            }
-        }
-
         final LivingEntity livingDamager = (LivingEntity) damager;
 
         weapon = livingDamager.getEquipment().getItemInMainHand();


### PR DESCRIPTION
Minecraft already has existing overdamage logic that compares incoming damage to the last damage and adjusts the final damage when the incoming damage is larger than the last damage during invulnerability ticks.

The OCM overdamage logic does not overwrite the existing overdamage logic and triggers strange interactions when entity.setLastDamage() is called.

OCM should rely on the existing overdamage logic instead of layering on top of it.

The vanilla overdamage logic can be found in the LivingEntity class's override of the Entity#hurt(DamageSource,float) method.

https://mappings.dev/1.21.3/net/minecraft/world/entity/Entity.html