### PR TITLE
Fix double counting weakness multiplier

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleOldPotionEffects.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleOldPotionEffects.java
@@ -164,7 +164,6 @@ public class ModuleOldPotionEffects extends OCMModule {
             event.setIsWeaknessModifierMultiplier(module().getBoolean("weakness.multiplier"));
             final double newWeaknessModifier = module().getDouble("weakness.modifier");
             event.setWeaknessModifier(newWeaknessModifier);
-            event.setWeaknessLevel(1);
             debug("Old weakness modifier: " + event.getWeaknessLevel() +
                     " New: " + newWeaknessModifier, damager);
         }

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/damage/OCMEntityDamageByEntityEvent.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/damage/OCMEntityDamageByEntityEvent.java
@@ -157,7 +157,7 @@ public class OCMEntityDamageByEntityEvent extends Event implements Cancellable {
                 .map(PotionEffect::getAmplifier)
                 .orElse(-1) + 1;
 
-        strengthModifier = strengthLevel * 3;
+        strengthModifier = 3;
 
         debug(livingDamager, "Strength Modifier: " + strengthModifier);
 
@@ -167,11 +167,11 @@ public class OCMEntityDamageByEntityEvent extends Event implements Cancellable {
         hasWeakness = weaknessAmplifier.isPresent() && (weaknessAmplifier.get() == -1 || weaknessAmplifier.get() == 0);
         weaknessLevel = weaknessAmplifier.orElse(-1) + 1;
 
-        weaknessModifier = weaknessLevel * -4;
+        weaknessModifier = -4;
 
         debug(livingDamager, "Weakness Modifier: " + weaknessModifier);
 
-        baseDamage = tempDamage + weaknessModifier - strengthModifier;
+        baseDamage = tempDamage - (weaknessModifier * weaknessLevel) - (strengthModifier * strengthLevel);
         debug(livingDamager, "Base tool damage: " + baseDamage);
     }
 


### PR DESCRIPTION
OCMEntityDamageByEntityEvent should be calculating the base damage by removing potion effect modifiers like weakness from the raw damage amount.

Instead of adding back the damage lost from the vanilla potion effect, The OCMEntityDamageByEntityEvent subtracts the weakness modifier and subtracts the weakness again in EntityDamageByEntityListener.


Reproduction Steps.
Attack an entity with a diamond sword without weakness. Base damage is 8.0 and final damage is 0.0 instead of the expected 4.0.

[config.yml.txt](https://github.com/user-attachments/files/17533001/config.yml.txt)
